### PR TITLE
Fix `[compat]` entries in `Project.toml`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,9 @@ Permutations = "2ae35dd2-176d-5d53-8349-f30d82d94d4f"
 
 [compat]
 julia = "1"
-AbstractLattices = "0"
-Permutations = "0"
-DataStructures = "0"
+AbstractLattices = "0.1, 0.2"
+Permutations = "0.3, 0.4"
+DataStructures = "0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
In the General registry, we now **strongly** discourage users from having `[compat]` entries of the form:
```toml
SomePackage = "0"
```

These `[compat]` entries are problematic because they include an infinite number of breaking releases.

This pull request fixes the `[compat]` entries in the `Project.toml` file for this package.

cc: @scheinerman